### PR TITLE
[CI] Deprecate python3.9 and add 3.13 and 3.14 to test matrix

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-14, macos-15-intel, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     name:
       Template Generation/Project Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
     steps:
@@ -64,11 +64,11 @@ jobs:
         run: nox -s template-tests --verbose
 
       - name: Run coverage tests
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         run: nox -s coverage --verbose
 
       - name: Upload coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         uses: codecov/codecov-action@v5.5.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -102,7 +102,7 @@ jobs:
   run_doctests:
     needs: style
     runs-on: ubuntu-latest
-    name: Doctests (ubuntu-latest / Python 3.12)
+    name: Doctests (ubuntu-latest / Python 3.13)
 
     steps:
       - name: Check out pybamm-cookie repository
@@ -114,6 +114,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
+          python-version: "3.13"
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
 
@@ -128,7 +129,7 @@ jobs:
   run_generated_project_doctests:
     needs: [template_test]
     runs-on: ubuntu-latest
-    name: Generated Project Doctests (ubuntu-latest / Python 3.12)
+    name: Generated Project Doctests (ubuntu-latest / Python 3.13)
 
     steps:
       - name: Check out pybamm-cookie repository
@@ -140,7 +141,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
-          python-version: "3.12"
+          python-version: "3.13"
           activate-environment: true
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 ]
 description = "A template for creating battery modeling projects based on PyBaMM"
 readme = "README.md"
-requires-python = ">=3.8"  # PyBaMM supports 3.8 and above
+requires-python = ">=3.10,<3.15"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",
@@ -23,10 +23,11 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",  # PyBaMM supports >=3.8,<3.12
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",  # PyBaMM supports >=3.10, <3.15
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
@@ -84,7 +85,7 @@ packages = [
   "src/pybamm_cookie",
   "tests"
 ]
-python_version = "3.11"
+python_version = "3.13"
 strict = false
 warn_return_any = false
 show_error_codes = true

--- a/template/{{ project_name }}/pyproject.toml.jinja
+++ b/template/{{ project_name }}/pyproject.toml.jinja
@@ -34,7 +34,7 @@ maintainers = [
 {%- endif %}
 description = "{{ project_short_description }}"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10,<3.15"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",
@@ -50,10 +50,11 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
 {%- if mypy %}
   "Typing :: Typed",
@@ -125,7 +126,7 @@ version_file = "src/{{ project_slug }}/_version.py"
 
 {%- if mypy %}
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.13"
 strict =  false
 warn_return_any = false
 show_error_codes = true

--- a/template/{{ project_name }}/{% if ci == 'github' %}.github{% endif %}/workflows/test_on_push.yml
+++ b/template/{{ project_name }}/{% if ci == 'github' %}.github{% endif %}/workflows/test_on_push.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Check style
         run: |
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, macos-14, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     name:
       Template Generation/Project Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
     steps:
@@ -59,11 +59,11 @@ jobs:
         run: nox -s user-tests
 
       - name: Run coverage tests
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         run: nox -s coverage
 
       - name: Upload coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         uses: codecov/codecov-action@v4.5.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
   run_doctests:
     needs: style
     runs-on: ubuntu-latest
-    name: Doctests (ubuntu-latest / Python 3.12)
+    name: Doctests (ubuntu-latest / Python 3.13)
 
     steps:
       - name: Check out pybamm-cookie repository
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Set up uv
         uses: yezz123/setup-uv@v4


### PR DESCRIPTION
- As python 3.9 is reaching EOL, have deprecated it and added 3.13 and 3.14 to the test matrix. 
- Have made 3.13 the standard version for testing docs.